### PR TITLE
Separate repo user from API user

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ jobs:
         api_user: example-user
         api_key: ${{ secrets.BINTRAY_API_KEY }} # An API key can be obtained from the user profile page.
         gpg_passphrase: ${{ secrets.BINTRAY_GPG_PASSPHRASE }} # Optional, for this to work Bintray requires a GPG public/private keypair configured for the repository owner (individual or organization).
+        repository_user: example-user
         repository: my_repository
         package: example-package
         version: '1.0'

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   gpg_passphrase:
     description: 'Passphrase for GPG key, see https://bintray.com/docs/api/#gpg_signing_passphrase. Only required when using a password-protected GPG key.'
     required: false
+  repository_user:
+    description: 'Repository owner username'
+    required: true
   repository:
     description: 'Name of the repository'
     required: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,12 +29,12 @@ then
 fi
 
 echo "Uploading file"
-curl --silent --show-error --fail --location --request PUT --upload-file "${1}" --user "${INPUT_API_USER}:${INPUT_API_KEY}" -H "${HEADER_GPG_PASSPHRASE}" -H "${HEADER_DEBIAN_DISTRIBUTION}" -H "${HEADER_DEBIAN_COMPONENT}" -H "${HEADER_DEBIAN_ARCHITECTURE}" "${INPUT_API_URL}/content/${INPUT_API_USER}/${INPUT_REPOSITORY}/${INPUT_PACKAGE}/${INPUT_VERSION}/${INPUT_UPLOAD_PATH}/${FILENAME};publish=${INPUT_PUBLISH}"
+curl --silent --show-error --fail --location --request PUT --upload-file "${1}" --user "${INPUT_API_USER}:${INPUT_API_KEY}" -H "${HEADER_GPG_PASSPHRASE}" -H "${HEADER_DEBIAN_DISTRIBUTION}" -H "${HEADER_DEBIAN_COMPONENT}" -H "${HEADER_DEBIAN_ARCHITECTURE}" "${INPUT_API_URL}/content/${INPUT_REPOSITORY_USER}/${INPUT_REPOSITORY}/${INPUT_PACKAGE}/${INPUT_VERSION}/${INPUT_UPLOAD_PATH}/${FILENAME};publish=${INPUT_PUBLISH}"
 echo "    -> Done."
 
 if [ "${INPUT_CALCULATE_METADATA}" = "true" ]
 then
     echo "Requesting metadata (re)-calculation"
-    curl --silent --show-error --fail --location --request POST --user "${INPUT_API_USER}:${INPUT_API_KEY}" -H "${HEADER_GPG_PASSPHRASE}" "${INPUT_API_URL}/calc_metadata/${INPUT_API_USER}/${INPUT_REPOSITORY}"
+    curl --silent --show-error --fail --location --request POST --user "${INPUT_API_USER}:${INPUT_API_KEY}" -H "${HEADER_GPG_PASSPHRASE}" "${INPUT_API_URL}/calc_metadata/${INPUT_REPOSITORY_USER}/${INPUT_REPOSITORY}"
     echo "    -> Done."
 fi


### PR DESCRIPTION
When uploading to an organization repo, you use your personal API access token (with your username) and the username in the repo path is that of the organization. This PR separates the two usernames into separate parameters, in order to make it possible to use this action to upload to organization repos.